### PR TITLE
Make multiprocessing optional, again

### DIFF
--- a/concurrent/futures/__init__.py
+++ b/concurrent/futures/__init__.py
@@ -20,6 +20,5 @@ import sys
 try:
     from concurrent.futures.process import ProcessPoolExecutor
 except ImportError:
-    # Jython doesn't have multiprocessing
-    if not sys.platform.startswith('java'):
-        raise
+    # some platforms don't have multiprocessing
+    pass


### PR DESCRIPTION
This used to be fixed, but then it was broken again for all platforms other than Jython. It seems pretty apparent that if there is an ImportError, then *whatever* platform this is running on does not have multiprocessing. Why the specific check for Java/Jython?

One of our users was trying to use this with [python-for-android](https://github.com/kivy/python-for-android), which does not have multiprocessing support either. I told him to make his own copy so he could remove those imports.