### PR TITLE
Issue #20319: concurrent.futures.wait() can block forever even if Fut…

### DIFF
--- a/concurrent/futures/_base.py
+++ b/concurrent/futures/_base.py
@@ -227,7 +227,8 @@ def as_completed(fs, timeout=None):
 
     finally:
         for f in fs:
-            f._waiters.remove(waiter)
+            with f._condition:
+                f._waiters.remove(waiter)
 
 DoneAndNotDoneFutures = collections.namedtuple(
         'DoneAndNotDoneFutures', 'done not_done')
@@ -274,7 +275,8 @@ def wait(fs, timeout=None, return_when=ALL_COMPLETED):
 
     waiter.event.wait(timeout)
     for f in fs:
-        f._waiters.remove(waiter)
+        with f._condition:
+            f._waiters.remove(waiter)
 
     done.update(waiter.finished_futures)
     return DoneAndNotDoneFutures(done, set(fs) - done)


### PR DESCRIPTION
…ures have completed

Applied https://github.com/python/cpython/commit/403f8cf425cd45a3ffcdd277091be465dce35532