### PR TITLE
Allow a callback to be called when each thread is started

### DIFF
--- a/concurrent/futures/thread.py
+++ b/concurrent/futures/thread.py
@@ -61,7 +61,10 @@ class _WorkItem(object):
 
 def _worker(before_run, executor_reference, work_queue):
     try:
-        before_run()
+        try:
+            before_run()
+        finally:
+            del before_run
         while True:
             work_item = work_queue.get(block=True)
             if work_item is not None:


### PR DESCRIPTION
It can be quite useful to have a callback run before each
thread starts to do work, to setup any thread-local context
or other thread specifics that will be used throughout the
threads lifecycle. Adding a callback as an __init__ argument
allows this to easily occur.