### PR TITLE
Attempt to handle KeyboardInterrupt exceptions

### DIFF
--- a/concurrent/futures/process.py
+++ b/concurrent/futures/process.py
@@ -119,11 +119,16 @@ def _process_worker(call_queue, result_queue):
             worker that it should exit when call_queue is empty.
     """
     while True:
-        call_item = call_queue.get(block=True)
-        if call_item is None:
-            # Wake up queue management thread
-            result_queue.put(None)
-            return
+        try:
+            call_item = call_queue.get(block=True)
+            if call_item is None:
+                # Wake up queue management thread
+                result_queue.put(None)
+                return
+        # since all child processes get the interrupt as well, we'll just pass
+        # on the exception and rely on our parent to handle this for us
+        except KeyboardInterrupt:
+            continue
         try:
             r = call_item.fn(*call_item.args, **call_item.kwargs)
         except BaseException:


### PR DESCRIPTION
For #25 there are effectively two problems. (1) the worker process doesn't handle the keyboard interrupt and as such the process pool cannot shutdown properly. c2ae8dc fixes this issue, such that the worker processes handle the exception and continue working. (2) There is no way to terminate a process pool. In the event that a keyboard interrupt was received and you do in fact want to exit-- you have no choice but to wait for the tasks to complete (assuming you have the first fix I mentioned). the addition of a terminate() method (f5727bd) allows you to do a more forcible shutdown of the pool-- clearing all unstarted jobs and forcibly killing all inflight processes.

Potential fix for #25