### PR TITLE
Add support for old-style exception objects.

### DIFF
--- a/concurrent/futures/process.py
+++ b/concurrent/futures/process.py
@@ -126,7 +126,7 @@ def _process_worker(call_queue, result_queue):
             return
         try:
             r = call_item.fn(*call_item.args, **call_item.kwargs)
-        except BaseException:
+        except:
             e = sys.exc_info()[1]
             result_queue.put(_ResultItem(call_item.work_id,
                                          exception=e))

--- a/concurrent/futures/thread.py
+++ b/concurrent/futures/thread.py
@@ -60,7 +60,7 @@ class _WorkItem(object):
 
         try:
             result = self.fn(*self.args, **self.kwargs)
-        except BaseException:
+        except:
             e, tb = sys.exc_info()[1:]
             self.future.set_exception_info(e, tb)
         else:
@@ -85,7 +85,7 @@ def _worker(executor_reference, work_queue):
                 work_queue.put(None)
                 return
             del executor
-    except BaseException:
+    except:
         _base.LOGGER.critical('Exception in worker', exc_info=True)
 
 


### PR DESCRIPTION
Python 2 permits raising old-style objects (objects that aren't instances of the `object` class).  Because these objects are not instances of `BaseException`, clauses like `except BaseException:` don't catch them.

Add support for handling old-style exception objects by:

  * using a class-less `except:` clause to catch old-style objects raised by tasks and done callbacks
  * using the proper exception object class type when raising a stored old-type exception during `result()`