### PR TITLE
Mark job as done

### DIFF
--- a/concurrent/futures/thread.py
+++ b/concurrent/futures/thread.py
@@ -75,6 +75,7 @@ def _worker(executor_reference, work_queue):
                 work_item.run()
                 # Delete references to object. See issue16284
                 del work_item
+                work_queue.task_done()
                 continue
             executor = executor_reference()
             # Exit if:


### PR DESCRIPTION
In order to know how many jobs are running `ThreadPoolExecutor()._work_queue.unfinished_tasks`