### PR TITLE
Backport py3 exit

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,3 +1,8 @@
+3.1.2
+=====
+
+- Backported explicit exit when install is attmepted on Python 3.
+
 3.1.1
 =====
 

--- a/README.rst
+++ b/README.rst
@@ -1,0 +1,36 @@
+.. image:: https://travis-ci.org/agronholm/pythonfutures.svg?branch=master
+  :target: https://travis-ci.org/agronholm/pythonfutures
+  :alt: Build Status
+
+This is a backport of the `concurrent.futures`_ standard library module to Python 2.
+
+It **does not** work on Python 3 due to Python 2 syntax being used in the codebase.
+Python 3 users should not attempt to install it, since the package is already included in the
+standard library.
+
+To conditionally require this library only on Python 2, you can do this in your ``setup.py``:
+
+.. code-block:: python
+
+    setup(
+        ...
+        extras_require={
+            ':python_version == "2.7"': ['futures']
+        }
+    )
+
+Or, using the newer syntax:
+
+.. code-block:: python
+
+    setup(
+        ...
+        install_requires={
+            'futures; python_version == "2.7"'
+        }
+    )
+
+.. warning:: The ``ProcessPoolExecutor`` class has known (unfixable) problems on Python 2 and
+   should not be relied on for mission critical work. Please see `Issue 29 <https://github.com/agronholm/pythonfutures/issues/29>`_ and `upstream bug report <https://bugs.python.org/issue9205>`_ for more details.
+
+.. _concurrent.futures: https://docs.python.org/library/concurrent.futures.html

--- a/setup.py
+++ b/setup.py
@@ -23,8 +23,9 @@ except ImportError:
     from distutils.core import setup
 
 setup(name='futures',
-      version='3.1.1',
+      version='3.1.2',
       description='Backport of the concurrent.futures package from Python 3.2',
+      long_description=readme,
       author='Brian Quinlan',
       author_email='brian@sweetapp.com',
       maintainer='Alex Gronholm',

--- a/setup.py
+++ b/setup.py
@@ -1,11 +1,19 @@
 #!/usr/bin/env python
-from warnings import warn
+# coding: utf-8
+from __future__ import print_function
+
+import os.path
 import sys
 
 if sys.version_info[0] > 2:
-    warn('This backport is meant only for Python 2.\n'
-         'Python 3 users do not need it, as the concurrent.futures '
-         'package is available in the standard library.')
+    print('This backport is meant only for Python 2.\n'
+          'It does not work on Python 3, and Python 3 users do not need it '
+          'as the concurrent.futures package is available in the standard library.\n'
+          'For projects that work on both Python 2 and 3, the dependency needs to be conditional '
+          'on the Python version, like so:\n'
+          "extras_require={':python_version == \"2.7\"': ['futures']}",
+          file=sys.stderr)
+    sys.exit(1)
 
 extras = {}
 try:


### PR DESCRIPTION
I would prefer to  make this against a 3.1x backport branch, but I'll make it against master since that's the closest I can.

As of today if I am in a python 3 environment and I install futures, 3.1.1 is installed:

```
(broken_python3) ~ $ pip3 install futures
Collecting futures
  Downloading https://files.pythonhosted.org/packages/cc/26/b61e3a4eb50653e8a7339d84eeaa46d1e93b92951978873c220ae64d0733/futures-3.1.1.tar.gz
Building wheels for collected packages: futures
  Running setup.py bdist_wheel for futures ... done
  Stored in directory: /Users/mpacer/Library/Caches/pip/wheels/f3/f9/c7/4fbf1faa6038faf183f6e3ea61f17a5f7eea5ab9a1dd7753fd
Successfully built futures
Installing collected packages: futures
Successfully installed futures-3.1.1
```

Unfortunately, this will still occur even after you release the next 3.2 version because pip3 will never download any version of futures that includes `"python_requires>=2.6, <3.0"`. It will continue to download 3.1.1 — which will break anyone's python3 concurrent.futures packages.

I don't think that you should leave out `python_requires` for any other versions of the package. There just needs to be some version of `futures` > 3.1.1 (e.g., 3.1.2) that has this explicit catch and exit.