### PR TITLE
Make test_idle_thread_reuse more reliable

### DIFF
--- a/test_futures.py
+++ b/test_futures.py
@@ -553,7 +553,9 @@ class ThreadPoolExecutorTest(ThreadPoolMixin, ExecutorTest):
     def test_idle_thread_reuse(self):
         executor = self.executor_type()
         executor.submit(mul, 21, 2).result()
+        time.sleep(0.001)
         executor.submit(mul, 6, 7).result()
+        time.sleep(0.001)
         executor.submit(mul, 3, 14).result()
         self.assertEqual(len(executor._threads), 1)
         executor.shutdown(wait=True)


### PR DESCRIPTION
depending on machine load or other unknown influences
on the Linux scheduler, the `test_idle_thread_reuse` test would often fail with

```
   File "test_futures.py", line 558, in test_idle_thread_reuse
     self.assertEqual(len(executor._threads), 1)
 AssertionError: 2 != 1
```

This PR was done while working on reproducible builds for openSUSE.